### PR TITLE
Fixed warning for snprintf call

### DIFF
--- a/libtorrent/src/alert.cpp
+++ b/libtorrent/src/alert.cpp
@@ -354,7 +354,7 @@ namespace libtorrent {
 	std::string dht_reply_data_alert::message() const
 	{
 		char msg[200];
-		snprintf(msg, sizeof(msg), "reply to dht getData received %d entries", m_lst.size());
+		snprintf(msg, sizeof(msg), "reply to dht getData received %lu entries", m_lst.size());
 		return msg;
 	}
 


### PR DESCRIPTION
This change seems to fix the following compilation warning:

```
alert.cpp: In member function 'virtual std::string libtorrent::dht_reply_data_alert::message() const':
alert.cpp:357:86: warning: format '%d' expects argument of type 'int', but argument 4 has type 'std::list<libtorrent::entry>::size_type {aka long unsigned int}' [-Wformat=]
snprintf(msg, sizeof(msg), "reply to dht getData received %d entries", m_lst.size());
                                                                                  ^
alert.cpp:357:86: warning: format '%d' expects argument of type 'int', but argument 4 has type 'std::list<libtorrent::entry>::size_type {aka long unsigned int}' [-Wformat=]
```
