### PR TITLE
Fix missing packages

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -64,8 +64,9 @@ for Ubuntu 12.04:
 for other Ubuntu & Debian:
 
 	sudo apt-get install libdb4.8-dev
-	sudo apt-get install libdb4.8++-dev
-	sudo apt-get install libboost1.37-dev
+	sudo apt-get install libdb++-dev
+	sudo apt-get install libboost-all-dev
+	
  (If using Boost 1.37, append -mt to the boost libraries in the makefile)
 
 Optional:


### PR DESCRIPTION
Package 'libdb4.8++-dev' has no installation candidate
