### PR TITLE
Fixed twister-qt.pro for boost > 1.46

### DIFF
--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -38,7 +38,6 @@ LIBS += \
    -l boost_filesystem$(BOOST_LIB_SUFFIX) \
    -l boost_program_options$(BOOST_LIB_SUFFIX) \
    -l boost_thread$(BOOST_LIB_SUFFIX) \
-   -l boost_chrono$(BOOST_LIB_SUFFIX) \
    -l db_cxx$(BDB_LIB_SUFFIX) \
    -l ssl \
    -l crypto \

--- a/twister-qt.pro
+++ b/twister-qt.pro
@@ -451,9 +451,14 @@ LIBS += $$join(BOOST_LIB_PATH,,-L,) $$join(BDB_LIB_PATH,,-L,) $$join(OPENSSL_LIB
 LIBS += -lssl -lcrypto -ldb_cxx$$BDB_LIB_SUFFIX
 # -lgdi32 has to happen after -lcrypto (see  #681)
 win32:LIBS += -lws2_32 -lshlwapi -lmswsock -lole32 -loleaut32 -luuid -lgdi32
-LIBS += -lboost_system$$BOOST_LIB_SUFFIX -lboost_filesystem$$BOOST_LIB_SUFFIX -lboost_program_options$$BOOST_LIB_SUFFIX -lboost_thread$$BOOST_THREAD_LIB_SUFFIX -lboost_chrono$$BOOST_LIB_SUFFIX
-win32:LIBS += -lboost_chrono$$BOOST_LIB_SUFFIX
-macx:LIBS += -lboost_chrono$$BOOST_LIB_SUFFIX
+LIBS += -lboost_system$$BOOST_LIB_SUFFIX -lboost_filesystem$$BOOST_LIB_SUFFIX -lboost_program_options$$BOOST_LIB_SUFFIX -lboost_thread$$BOOST_THREAD_LIB_SUFFIX
+
+contains(USE_BOOST_46,1) {
+    message(Building with boost 1.4.6. Excluding chrono library.)
+} else {
+    message(Building with boost over 1.4.6. Including chrono library.)
+    LIBS += -lboost_chrono$$BOOST_LIB_SUFFIX
+}
 
 contains(RELEASE, 1) {
     !win32:!macx {


### PR DESCRIPTION
[edited to make things more clear]
Twister must be linked to libboost_chrono when building on unix with boost > 1.46. I have fixed twister.qt-pro to do so, but I'm not sure (and can't test at the moment), if it still works with boost < 1.46, since the code tests for version 1.46 only.
