### PR TITLE
Correcting autotools.sh to autotool.sh

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -104,7 +104,7 @@ Installing the dependencies using MacPorts is very straightforward.
 
 Once installed dependencies, do:
 
-    ./autotools.sh
+    ./autotool.sh
     ./configure --enable-logging
     make
 


### PR DESCRIPTION
The docs say ./autotools.sh but the file is named autotool.sh
