### PR TITLE
Libtorrent requires Boost 1.44

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -83,7 +83,7 @@ AC_CACHE_CHECK([for __attribute__((visibility("hidden")))],
 AS_ECHO
 AS_ECHO "Checking for boost libraries:"
 
-AX_BOOST_BASE([1.36])
+AX_BOOST_BASE([1.44])
 
 AX_BOOST_SYSTEM()
 AS_IF([test -z "$BOOST_SYSTEM_LIB"],


### PR DESCRIPTION
As gathered in miguelfreitas/twister-core#18 , Libtorrent requires Boost 1.44+
