### PR TITLE
faster DHT refresh

### DIFF
--- a/libtorrent/include/libtorrent/kademlia/node.hpp
+++ b/libtorrent/include/libtorrent/kademlia/node.hpp
@@ -300,6 +300,7 @@ private:
 
 	ptime m_last_tracker_tick;
 	ptime m_next_storage_refresh;
+	int m_refresh_per_tick;
 	std::pair<node_id, int> m_last_refreshed_item;
 
 	// secret random numbers used to create write tokens


### PR DESCRIPTION
Users who post messages frequently and who are subscribed to many other users have issue with mentions propagation in DHT (see issues #216, #165). My tests show that it might be because of users have many items in m_storage_table and as a result it takes long time to refresh all of them on DHT. For example, I have about 4000 items that should be refreshed (and about 10000 in total), and update of one item per five seconds "tick" leads to 5.5 hours of full refresh cycle.

My patch allows to update several items per tick, and full refresh cycle should be about 30 minutes.
