### PR TITLE
increase allowed size of putData request

### DIFF
--- a/libtorrent/src/kademlia/node.cpp
+++ b/libtorrent/src/kademlia/node.cpp
@@ -1359,7 +1359,7 @@ void node_impl::incoming_request(msg const& m, entry& e)
 
 		// pointer and length to the whole entry
 		std::pair<char const*, int> buf = msg_keys[mk_p]->data_section();
-		int maxSize = (multi) ? 512 : 8192; // single is bigger for avatar image etc
+		int maxSize = (multi) ? 768 : 8192; // single is bigger for avatar image etc
 		// Note: when increasing maxSize, check m_buf_size @ udp_socket.cpp.
 		if (buf.second > maxSize || buf.second <= 0)
 		{


### PR DESCRIPTION
Size of 140-characters UTF-8 message may be up to 140*4=560 bytes, so current 512-bytes limit is not sufficient to store some messages.
