### PR TITLE
Remove a ToDo that seems like a bad idea

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -13,10 +13,6 @@ newpostmsg needs to be provided to receive posts with signature field added.
 
 Features
 ================
-- Besides increasing the maximum number of pieces, a more pressing issue to save bandwidth and
-torrent download time would be to define the first piece to download/store locally. People don't
-need to maintain the entire post history for everybody they follow, they could just keep the last
-ones. This has to be implemented.
 
 - Store a dht resource "publickey" containing not only the public key itself but also information
 needed to validate it by a lightweight client. That includes: block hash, block height and partial


### PR DESCRIPTION
If eveyone just keeps the latests pieces, then who is going to seed the earlier ones if someone actually does want them at some point?
If I understand correctly, the DHT can be modified to remove items, so the earlier pieces must be kept by enough people to distribute them.
Or am I misunderstanding?
