### PR TITLE
Remove NDEBUG option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -442,7 +442,7 @@ AS_CASE(["$ARG_ENABLE_DEBUG"],
    ],
   ["no"], [
       AC_MSG_RESULT([no])
-      AC_DEFINE([NDEBUG],[1],[Define to disable debug code.])
+      #AC_DEFINE([NDEBUG],[1],[Define to disable debug code.])
       #COMPILETIME_OPTIONS="$COMPILETIME_OPTIONS -DNDEBUG "
       DEBUGFLAGS="-Os"
    ],


### PR DESCRIPTION
Bitcoin code is crashed (SEGFAULT) being compiled with `-DNDEBUG` option (see https://github.com/bitcoin/bitcoin/blob/master/src/main.cpp#L32)
