### PR TITLE
Support double hashtags (and double mentions) in newpostmsg

### DIFF
--- a/src/twister.cpp
+++ b/src/twister.cpp
@@ -1798,7 +1798,7 @@ Value newpostmsg(const Array& params, bool fHelp)
     BOOST_FOREACH(string const& token, tokens) {
         if( token.length() >= 2 ) {
             char delim = token.at(0);
-            if( delim != '#' && delim != '@') continue;
+            if( delim != '#' && delim != '@' ) continue;
             string target = (delim == '#') ? "hashtag" : "mention";
             string word = token.substr(1);
 #ifdef HAVE_BOOST_LOCALE


### PR DESCRIPTION
See https://github.com/miguelfreitas/twister-html/commit/706f17869bcb59200b9247df187a54dd52990720 (https://github.com/miguelfreitas/twister-html/pull/202) and https://github.com/miguelfreitas/twister-core/commit/07edcd08a9e5c43c6442b9c8d65cf9b44b2cfd9e (https://github.com/miguelfreitas/twister-core/pull/295)
