### PR TITLE
Force unsing python2

### DIFF
--- a/twister-control.py
+++ b/twister-control.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # very simple wrapper for starting twisterd and launching the web browser
 #


### PR DESCRIPTION
On systems with python3 installed and set as default the script will not run otherwise.
