### PR TITLE
fix memory size bug

### DIFF
--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -19,7 +19,7 @@ void InitRPCMining()
 {
     // getwork/getblocktemplate mining rewards paid here:
     salt.resize(4);
-    RAND_bytes(salt.data(), sizeof(salt));
+    RAND_bytes(salt.data(), 4);
 }
 
 void ShutdownRPCMining()


### PR DESCRIPTION
sizeof(salt) is the std lib struct size, not the data size!, It is much bigger then 4, can overwrite some memory cause core dump.

I find this bug by run twister in valgrind, but valgrind cause running too slow.