### PR TITLE
Use cppcheck on src ; gitignore more outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,11 @@ src/bitcoind
 src/test_bitcoin
 src/.deps/
 src/.dirstamp
+libtorrent/src/.deps/
+libtorrent/src/.dirstamp
+libtorrent/src/kademlia/.deps/
+libtorrent/src/kademlia/.dirstamp
+build-aux/
 .*.swp
 *.*~*
 *.bak
@@ -59,13 +64,7 @@ build
 
 !src/leveldb-*/Makefile
 
-build-aux/
-libtool
-libtorrent/src/.deps/
-libtorrent/src/.dirstamp
-libtorrent/src/kademlia/.deps/
-libtorrent/src/kademlia/.dirstamp
-
 # Targets
+libtool
 twister-control
 twisterd

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ src/*.exe
 src/bitcoin
 src/bitcoind
 src/test_bitcoin
+src/.deps/
+src/.dirstamp
 .*.swp
 *.*~*
 *.bak
@@ -56,3 +58,14 @@ qrc_*.cpp
 build
 
 !src/leveldb-*/Makefile
+
+build-aux/
+libtool
+libtorrent/src/.deps/
+libtorrent/src/.dirstamp
+libtorrent/src/kademlia/.deps/
+libtorrent/src/kademlia/.dirstamp
+
+# Targets
+twister-control
+twisterd

--- a/Makefile.am
+++ b/Makefile.am
@@ -202,7 +202,7 @@ clean-local:
 	rm -f src/leveldb/*/*.gcno src/leveldb/helpers/memenv/*.gcno
 
 cppcheck:
-	cppcheck ./src --force --quiet --suppressions ./src/cppcheck-suppressions.txt
+	cppcheck ./src -j 4 --force --quiet --suppressions ./src/cppcheck-suppressions.txt
 
 pixmapsdir = $(datadir)/pixmaps
 pixmaps_DATA = share/pixmaps/*

--- a/Makefile.am
+++ b/Makefile.am
@@ -202,7 +202,7 @@ clean-local:
 	rm -f src/leveldb/*/*.gcno src/leveldb/helpers/memenv/*.gcno
 
 cppcheck:
-	cppcheck ./src --force --quiet ./src/cppcheck-supressions.txt
+	cppcheck ./src --force --quiet --suppressions ./src/cppcheck-suppressions.txt
 
 pixmapsdir = $(datadir)/pixmaps
 pixmaps_DATA = share/pixmaps/*

--- a/Makefile.am
+++ b/Makefile.am
@@ -201,6 +201,9 @@ clean-local:
 	-$(MAKE) -C src/leveldb clean
 	rm -f src/leveldb/*/*.gcno src/leveldb/helpers/memenv/*.gcno
 
+cppcheck:
+	cppcheck ./src --force --quiet ./src/cppcheck-supressions.txt
+
 pixmapsdir = $(datadir)/pixmaps
 pixmaps_DATA = share/pixmaps/*
 

--- a/src/cppcheck-suppressions.txt
+++ b/src/cppcheck-suppressions.txt
@@ -1,0 +1,2 @@
+uninitstring:src/scrypt.cpp:83
+arrayIndexOutOfBounds:src/test/DoS_tests.cpp:300


### PR DESCRIPTION
Introduce [cppcheck](http://cppcheck.sourceforge.net/) for static analysis of code in the `./src/` directory, and ignore the invalid warnings.  (Not introduced for `./libtorrent` yet.)

Ignore some additional output files in `.gitignore`.