### PR TITLE
prevents posting with backward or existing k

### DIFF
--- a/src/twister.cpp
+++ b/src/twister.cpp
@@ -1422,6 +1422,9 @@ bool acceptSignedPost(char const *data, int data_size, std::string username, int
                 } else if( k != seq ) {
                     sprintf(errbuf,"expected piece '%d' got '%d'",
                            seq, k);
+                } else if (torrentLastHave(username) >= seq) {
+                    sprintf(errbuf, "duplicate or backward post sequence number (k=%d)",
+                            seq);
                 } else if( !validatePostNumberForUser(username, k) ) {
                     sprintf(errbuf,"too much posts from user '%s' rejecting post",
                             username.c_str());


### PR DESCRIPTION
sometimes clients are lazy to update *lasthave* values or users can't be patient, especially on retwisting k and lastk values can be equal, so that pieces can't be added to swarm but it is put on dht, like...
![lastk-error](https://cloud.githubusercontent.com/assets/12120467/7429812/3cae0032-f011-11e4-99f6-801b1d680d73.png)

and it prevents also posting with backward k...
