### PR TITLE
spam message queue

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -96,7 +96,9 @@ extern bool fHaveGUI;
 // Settings
 extern int64 nTransactionFee;
 
-extern string strSpamMessage;
+extern CCriticalSection cs_spamMessages;
+static const string strSpamMessage = "Promoted posts are needed to run the network infrastructure. If you want to help, start generating blocks and advertise. [en]";
+extern std::list<string> spamMessages;
 extern string strSpamUser;
 
 // Minimum disk space required - used in CheckDiskSpace()


### PR DESCRIPTION
* adding a spam message list instead of a single message... so user may publish different message with each block.
* adding `m_receivedSpamHeight` to display correct height (i.e. k for spams) in home timeline, so if an user reply to it, related spam can be displayed...