### PR TITLE
Fix rpcallowip to use the real bridge IP in the Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,5 +21,5 @@ ENV HOME /root
 VOLUME /root/.twister
 
 # Run twisterd by default
-ENTRYPOINT ["/twister-core/twisterd", "-rpcuser=user", "-rpcpassword=pwd", "-rpcallowip=172.17.42.1", "-htmldir=/twister-html", "-printtoconsole", "-port=28333"]
+ENTRYPOINT ["/twister-core/docker-entrypoint"]
 EXPOSE 28332

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+BRIDGE_IP=$(ip ro get 8.8.8.8 | grep -oP '(?<=via )([\d\.]+)')
+
+exec /twister-core/twisterd -rpcuser=user -rpcpassword=pwd -rpcallowip=${BRIDGE_IP} -htmldir=/twister-html -printtoconsole -port=28333 $*


### PR DESCRIPTION
This is needed for Docker >=1.9 because the bridge IP is not necessarily
172.17.42.1 anymore. (See https://github.com/docker/docker/issues/17305
for reference.)