### PR TITLE
rollback #396: the solution doesn't work on another machines.

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -54,7 +54,7 @@ Instructions: Homebrew
 2. Build twister using autotool
 
         ./autotool.sh
-        ./configure --enable-logging --with-openssl=/usr/local/opt/openssl
+        ./configure --enable-logging --with-openssl=/usr/local/opt/openssl --with-libdb=/usr/local/opt/berkeley-db4
         make
 (If you have multi core CPU, use "make -j N" where N = the number of your cores)
 


### PR DESCRIPTION
Following option required on another OS X Sierra machines:
--with-libdb=/usr/local/opt/berkeley-db4 

Looks like it was local problem after upgrade,  sorry about that.