### PR TITLE
fix boost-1.67 build

### DIFF
--- a/libtorrent/include/libtorrent/ip_filter.hpp
+++ b/libtorrent/include/libtorrent/ip_filter.hpp
@@ -40,8 +40,14 @@ POSSIBILITY OF SUCH DAMAGE.
 #pragma warning(push, 1)
 #endif
 
-#include <boost/limits.hpp>
+#include <boost/version.hpp>
+#if BOOST_VERSION >= 106700
+#include <boost/next_prior.hpp>
+#else
 #include <boost/utility.hpp>
+#endif
+
+#include <boost/limits.hpp>
 #include <boost/tuple/tuple.hpp>
 
 #ifdef _MSC_VER
@@ -312,4 +318,3 @@ private:
 }
 
 #endif
-

--- a/libtorrent/include/libtorrent/kademlia/routing_table.hpp
+++ b/libtorrent/include/libtorrent/kademlia/routing_table.hpp
@@ -36,7 +36,13 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <vector>
 #include <boost/cstdint.hpp>
 
+#include <boost/version.hpp>
+#if BOOST_VERSION >= 106700
+#include <boost/next_prior.hpp>
+#else
 #include <boost/utility.hpp>
+#endif
+
 #include <boost/tuple/tuple.hpp>
 #include <boost/array.hpp>
 #include <set>
@@ -220,4 +226,3 @@ private:
 } } // namespace libtorrent::dht
 
 #endif // ROUTING_TABLE_HPP
-


### PR DESCRIPTION
to get twister working on Ubuntu 18.10