### PR TITLE
Fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 #
 # Dockerfile for building Twister peer-to-peer micro-blogging
 #
-FROM ubuntu:14.04
+FROM ubuntu:20.04
 
 # Install twister-core
 RUN apt-get update
-RUN apt-get install -y git autoconf libtool build-essential libboost-all-dev libssl-dev libdb++-dev libminiupnpc-dev && apt-get clean
-#RUN git clone https://github.com/miguelfreitas/twister-core.git
-ADD . /twister-core
+RUN DEBIAN_FRONTEND=noninteractive  apt-get install -y iproute2 git autoconf libtool build-essential libboost-all-dev libssl-dev libdb++-dev libminiupnpc-dev automake
+RUN git clone https://github.com/miguelfreitas/twister-core.git
+COPY . /twister-core
 RUN cd twister-core && \
     ./bootstrap.sh && \
     make

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM ubuntu:20.04
 
 # Install twister-core
 RUN apt-get update
-RUN DEBIAN_FRONTEND=noninteractive  apt-get install -y iproute2 git autoconf libtool build-essential libboost-all-dev libssl-dev libdb++-dev libminiupnpc-dev automake
+RUN DEBIAN_FRONTEND=noninteractive  apt-get install -y iproute2 git autoconf libtool build-essential libboost-all-dev libssl-dev libdb++-dev libminiupnpc-dev automake && apt-get clean
 RUN git clone https://github.com/miguelfreitas/twister-core.git
 COPY . /twister-core
 RUN cd twister-core && \


### PR DESCRIPTION
**why**
prior to this docker build was failing on master. 
see https://github.com/miguelfreitas/twister-core/issues/439

this branch:
```
% ./twister-on-docker run
Running twister
da2e2ec2b7c708f6490f62b9e5ac65190c2ab0c9988e9fd8bc04d2cb036a52d2
Twister should now be running at http://localhost:28332 (access with "user" / "pwd")
gabriel@Wafas-Air twister-core % docker ps
CONTAINER ID   IMAGE            COMMAND                  CREATED         STATUS         PORTS                      NAMES
da2e2ec2b7c7   twister          "/twister-core/docke…"   8 seconds ago   Up 2 seconds   0.0.0.0:28332->28332/tcp   jolly_hermann
```

bumping the ubuntu version, and using packages included in the docs has seemed to resolve this