### PR TITLE
upgrade fm construction

### DIFF
--- a/libtorrent/src/file.cpp
+++ b/libtorrent/src/file.cpp
@@ -1833,7 +1833,7 @@ typedef struct _FILE_ALLOCATED_RANGE_BUFFER {
 #ifdef FIEMAP_EXTENT_UNKNOWN
 		// for documentation of this feature
 		// http://lwn.net/Articles/297696/
-		struct
+		union
 		{
 			struct fiemap fiemap;
 			struct fiemap_extent extent;


### PR DESCRIPTION
Looks like `struct` definition is deprecated by causing error on Debian 12 / Ubuntu 23.10  #11 

```
compilation error: flexible array member ‘fiemap::fm_extents’` 
```

Solution replaces `struct` data type to `union` even possible to change `fiemap`/`fiemap_extent` positions (last one does not in use just for memory size allocation)

p.s. [twisterarmy](https://github.com/twisterarmy/twister-core/tree/twisterarmy) branch already includes this patch if somebody have same error on twister-core compilation.